### PR TITLE
Shift to Meta inheritance to fix ordering

### DIFF
--- a/opencivicdata/elections/models/contests/ballot_measure.py
+++ b/opencivicdata/elections/models/contests/ballot_measure.py
@@ -104,7 +104,7 @@ class BallotMeasureContestSource(LinkBase):
         db_table = 'opencivicdata_ballotmeasurecontestsource'
 
 
-class BallotMeasureContest(ContestBase):
+class RetentionContest(ContestBase):
     """
     A subclass of ContestBase wherein an officeholder may retain or lose a Post.
 

--- a/opencivicdata/elections/models/contests/ballot_measure.py
+++ b/opencivicdata/elections/models/contests/ballot_measure.py
@@ -41,7 +41,7 @@ class BallotMeasureContest(ContestBase):
                   "BallotMeasureContest.",
     )
 
-    class Meta:
+    class Meta(ContestBase.Meta):
         db_table = 'opencivicdata_ballotmeasurecontest'
 
 
@@ -104,7 +104,7 @@ class BallotMeasureContestSource(LinkBase):
         db_table = 'opencivicdata_ballotmeasurecontestsource'
 
 
-class RetentionContest(ContestBase):
+class BallotMeasureContest(ContestBase):
     """
     A subclass of ContestBase wherein an officeholder may retain or lose a Post.
 
@@ -133,7 +133,7 @@ class RetentionContest(ContestBase):
                   "person in a specific public office.",
     )
 
-    class Meta:
+    class Meta(ContestBase.Meta):
         db_table = 'opencivicdata_retentioncontest'
 
 

--- a/opencivicdata/elections/models/contests/candidate.py
+++ b/opencivicdata/elections/models/contests/candidate.py
@@ -40,7 +40,7 @@ class CandidateContest(ContestBase):
                   "previously undecided contest, reference to that CandidateContest.",
     )
 
-    class Meta:
+    class Meta(ContestBase.Meta):
         db_table = 'opencivicdata_candidatecontest'
 
 


### PR DESCRIPTION
The ``ordering`` setting of the CandidateContest, BallotMeasureContest and RetentionContest parent is not being inherited due to the issue described [here](https://docs.djangoproject.com/en/1.11/topics/db/models/#meta-inheritance) in the Django documentation. I've tried to correct it. 