### PR TITLE
Ignore DisallowedModelAdminLookup error from non registered models

### DIFF
--- a/opencivicdata/core/admin/base.py
+++ b/opencivicdata/core/admin/base.py
@@ -14,6 +14,11 @@ class ModelAdmin(admin.ModelAdmin):
     def has_add_permission(self, request):
         return False
 
+    # To ignore `DisallowedModelAdminLookup` error because of non
+    # registered models
+    def lookup_allowed(self, request, key):
+        return True
+
 
 class ReadOnlyTabularInline(admin.TabularInline):
     def has_add_permission(self, request):

--- a/opencivicdata/core/admin/person.py
+++ b/opencivicdata/core/admin/person.py
@@ -81,8 +81,3 @@ class PersonAdmin(ModelAdmin):
     get_memberships.allow_tags = True
 
     list_display = ('name', 'id', 'get_memberships')
-
-    # Since `Membership` objects are not registered on admin panel.
-    # So to ignore `DisallowedModelAdminLookup` error.
-    def lookup_allowed(self, request, key):
-        return True


### PR DESCRIPTION
The models which are not registered on Django admin panel will give `DisallowedModelAdminLookup` error. To perform those queries via `admintools` these changes have been made.