### PR TITLE
Edits to docstrings on core and elections models

### DIFF
--- a/opencivicdata/core/models/division.py
+++ b/opencivicdata/core/models/division.py
@@ -36,9 +36,12 @@ class Division(models.Model):
     A political geography, which may have multiple boundaries over its lifetime.
 
     Types of divisions include, among others:
-    * Governmental jurisdiction - A division that a government has jurisdiction over. (e.g. North Carolina)
-    * Political district - A division that elects a representative to a legislature. (e.g. North Carolina Congressional District 4)
-    * Service zone - An area to which a government provides a service. (e.g. Washington DC Police District 105)
+    * Governmental jurisdiction - A division that a government has jurisdiction over.
+    (e.g. North Carolina)
+    * Political district - A division that elects a representative to a legislature.
+    (e.g. North Carolina Congressional District 4)
+    * Service zone - An area to which a government provides a service.
+    (e.g. Washington DC Police District 105)
     """
     objects = DivisionManager()
 

--- a/opencivicdata/core/models/division.py
+++ b/opencivicdata/core/models/division.py
@@ -32,6 +32,14 @@ class DivisionManager(models.Manager):
 
 @python_2_unicode_compatible
 class Division(models.Model):
+    """
+    A political geography, which may have multiple boundaries over its lifetime.
+
+    Types of divisions include, among others:
+    * Governmental jurisdiction - A division that a government has jurisdiction over. (e.g. North Carolina)
+    * Political district - A division that elects a representative to a legislature. (e.g. North Carolina Congressional District 4)
+    * Service zone - An area to which a government provides a service. (e.g. Washington DC Police District 105)
+    """
     objects = DivisionManager()
 
     id = models.CharField(max_length=300, primary_key=True)

--- a/opencivicdata/core/models/jurisdiction.py
+++ b/opencivicdata/core/models/jurisdiction.py
@@ -10,6 +10,13 @@ from .division import Division
 
 @python_2_unicode_compatible
 class Jurisdiction(OCDBase):
+    """
+    A Jurisdiction represents a logical unit of governance.
+
+    Examples would include: the United States Federal Government, the Government
+    of the District of Columbia, the Lexington-Fayette Urban County Government,
+    or the Wake County Public School System.
+    """
     id = OCDIDField(ocd_type='jurisdiction')
     name = models.CharField(max_length=300)
     url = models.URLField(max_length=2000)

--- a/opencivicdata/core/models/people_orgs.py
+++ b/opencivicdata/core/models/people_orgs.py
@@ -13,6 +13,9 @@ from ... import common
 
 @python_2_unicode_compatible
 class ContactDetailBase(RelatedBase):
+    """
+    A base class for ContactDetail models.
+    """
     type = models.CharField(max_length=50, choices=common.CONTACT_TYPE_CHOICES)
     value = models.CharField(max_length=300)
     note = models.CharField(max_length=300, blank=True)
@@ -27,6 +30,9 @@ class ContactDetailBase(RelatedBase):
 
 @python_2_unicode_compatible
 class OtherNameBase(RelatedBase):
+    """
+    A base class for OtherName models.
+    """
     name = models.CharField(max_length=500, db_index=True)
     note = models.CharField(max_length=500, blank=True)
     start_date = models.CharField(max_length=10, blank=True)    # YYYY[-MM[-DD]]
@@ -43,6 +49,9 @@ class OtherNameBase(RelatedBase):
 
 @python_2_unicode_compatible
 class Organization(OCDBase):
+    """
+    A group of people, typically in a legislative or rule-making context.
+    """
     id = OCDIDField(ocd_type='organization')
     name = models.CharField(max_length=300)
     image = models.URLField(blank=True, max_length=2000)
@@ -88,6 +97,9 @@ class Organization(OCDBase):
 
 @python_2_unicode_compatible
 class OrganizationIdentifier(IdentifierBase):
+    """
+    Upstream identifiers of an Organization.
+    """
     organization = models.ForeignKey(Organization, related_name='identifiers')
 
     def __str__(self):
@@ -99,6 +111,9 @@ class OrganizationIdentifier(IdentifierBase):
 
 
 class OrganizationName(OtherNameBase):
+    """
+    Alternate or former name for an Organization.
+    """
     organization = models.ForeignKey(Organization, related_name='other_names')
 
     class Meta:
@@ -106,6 +121,9 @@ class OrganizationName(OtherNameBase):
 
 
 class OrganizationContactDetail(ContactDetailBase):
+    """
+    Contact information for an Organization.
+    """
     organization = models.ForeignKey(Organization, related_name='contact_details')
 
     class Meta:
@@ -113,6 +131,9 @@ class OrganizationContactDetail(ContactDetailBase):
 
 
 class OrganizationLink(LinkBase):
+    """
+    URL for a document about an Organization.
+    """
     organization = models.ForeignKey(Organization, related_name='links')
 
     class Meta:
@@ -120,6 +141,9 @@ class OrganizationLink(LinkBase):
 
 
 class OrganizationSource(LinkBase):
+    """
+    Source used in assembling an Organization.
+    """
     organization = models.ForeignKey(Organization, related_name='sources')
 
     class Meta:
@@ -128,6 +152,9 @@ class OrganizationSource(LinkBase):
 
 @python_2_unicode_compatible
 class Post(OCDBase):
+    """
+    A position in an organization that exists independently of the person holding it.
+    """
     id = OCDIDField(ocd_type='post')
     label = models.CharField(max_length=300)
     role = models.CharField(max_length=300, blank=True)
@@ -149,6 +176,9 @@ class Post(OCDBase):
 
 
 class PostContactDetail(ContactDetailBase):
+    """
+    Contact information for whoever currently occupies a Post.
+    """
     post = models.ForeignKey(Post, related_name='contact_details')
 
     class Meta:
@@ -156,6 +186,9 @@ class PostContactDetail(ContactDetailBase):
 
 
 class PostLink(LinkBase):
+    """
+    URL for a document about a Post.
+    """
     post = models.ForeignKey(Post, related_name='links')
 
     class Meta:
@@ -185,6 +218,9 @@ class PersonQuerySet(QuerySet):
 
 @python_2_unicode_compatible
 class Person(OCDBase):
+    """
+    An individual that has served in a political office.
+    """
     objects = PersonQuerySet.as_manager()
 
     id = OCDIDField(ocd_type='person')
@@ -213,6 +249,9 @@ class Person(OCDBase):
 
 
 class PersonIdentifier(IdentifierBase):
+    """
+    Upstream identifier for a Person.
+    """
     person = models.ForeignKey(Person, related_name='identifiers')
 
     class Meta:
@@ -220,6 +259,9 @@ class PersonIdentifier(IdentifierBase):
 
 
 class PersonName(OtherNameBase):
+    """
+    Alternate or former name of a Person.
+    """
     person = models.ForeignKey(Person, related_name='other_names')
 
     class Meta:
@@ -227,6 +269,9 @@ class PersonName(OtherNameBase):
 
 
 class PersonContactDetail(ContactDetailBase):
+    """
+    Contact information for a Person.
+    """
     person = models.ForeignKey(Person, related_name='contact_details')
 
     class Meta:
@@ -234,6 +279,9 @@ class PersonContactDetail(ContactDetailBase):
 
 
 class PersonLink(LinkBase):
+    """
+    URL for a document about a Person.
+    """
     person = models.ForeignKey(Person, related_name='links')
 
     class Meta:
@@ -241,6 +289,9 @@ class PersonLink(LinkBase):
 
 
 class PersonSource(LinkBase):
+    """
+    Source used in assembling a Person.
+    """
     person = models.ForeignKey(Person, related_name='sources')
 
     class Meta:
@@ -249,6 +300,9 @@ class PersonSource(LinkBase):
 
 @python_2_unicode_compatible
 class Membership(OCDBase):
+    """
+    A relationship between a Person and an Organization, possibly including a Post.
+    """
     id = OCDIDField(ocd_type='membership')
     organization = models.ForeignKey(Organization, related_name='memberships')
     person = models.ForeignKey(Person, related_name='memberships', null=True)
@@ -272,6 +326,9 @@ class Membership(OCDBase):
 
 
 class MembershipContactDetail(ContactDetailBase):
+    """
+    Contact information for Person at an Organization.
+    """
     membership = models.ForeignKey(Membership, related_name='contact_details')
 
     class Meta:
@@ -279,6 +336,9 @@ class MembershipContactDetail(ContactDetailBase):
 
 
 class MembershipLink(LinkBase):
+    """
+    URL for a document about a Person's relationship to an Organization.
+    """
     membership = models.ForeignKey(Membership, related_name='links')
 
     class Meta:

--- a/opencivicdata/elections/models/candidacy.py
+++ b/opencivicdata/elections/models/candidacy.py
@@ -21,7 +21,7 @@ from opencivicdata.core.models import (
 @python_2_unicode_compatible
 class Candidacy(OCDBase):
     """
-    A person competing in an election contest to hold a specific office for a term.
+    A person seeking election to hold a specific public office for a term.
     """
     id = OCDIDField(
         ocd_type='candidacy',
@@ -105,7 +105,7 @@ class Candidacy(OCDBase):
 
 class CandidacySource(LinkBase):
     """
-    Source used in assembling the Candidacy.
+    Source used in assembling a Candidacy.
     """
     candidacy = models.ForeignKey(
         Candidacy,

--- a/opencivicdata/elections/models/contests/ballot_measure.py
+++ b/opencivicdata/elections/models/contests/ballot_measure.py
@@ -13,7 +13,7 @@ from .base import ContestBase
 
 class BallotMeasureContest(ContestBase):
     """
-    A subclass of ContestBase for representing a ballot measure before voters.
+    A contest in which voters select from among options proposed in a ballot measure.
     """
     description = models.TextField(
         help_text="Text describing the purpose and/or potential outcomes of the "
@@ -70,7 +70,7 @@ class BallotMeasureContestOption(models.Model):
 @python_2_unicode_compatible
 class BallotMeasureContestIdentifier(IdentifierBase):
     """
-    Upstream identifiers of the BallotMeasureContest, if any exist.
+    Upstream identifiers of a BallotMeasureContest.
 
     For example, identfiers assigned by a Secretary of State, county or city
     elections office.
@@ -92,7 +92,7 @@ class BallotMeasureContestIdentifier(IdentifierBase):
 
 class BallotMeasureContestSource(LinkBase):
     """
-    Source used in assembling the BallotMeasureContest.
+    Source used in assembling a BallotMeasureContest.
     """
     contest = models.ForeignKey(
         BallotMeasureContest,
@@ -106,9 +106,9 @@ class BallotMeasureContestSource(LinkBase):
 
 class RetentionContest(ContestBase):
     """
-    A subclass of ContestBase wherein an officeholder may retain or lose a Post.
+    A contest where voters vote to retain or recall a current office holder.
 
-    For example, a judicial retention or recall election.
+    These contests include judicial retention or recall elections.
     """
     description = models.TextField(
         help_text="Text describing the purpose and/or potential outcomes of the "
@@ -162,7 +162,7 @@ class RetentionContestOption(models.Model):
 @python_2_unicode_compatible
 class RetentionContestIdentifier(IdentifierBase):
     """
-    Upstream identifiers of the RetentionMeasureContest, if any exist.
+    Upstream identifiers of a RetentionContest.
 
     For example, identfiers assigned by a Secretary of State, county or city
     elections office.
@@ -184,7 +184,7 @@ class RetentionContestIdentifier(IdentifierBase):
 
 class RetentionContestSource(LinkBase):
     """
-    Source used in assembling the RetentionContest.
+    Source used in assembling a RetentionContest.
     """
     contest = models.ForeignKey(
         RetentionContest,

--- a/opencivicdata/elections/models/contests/candidate.py
+++ b/opencivicdata/elections/models/contests/candidate.py
@@ -13,7 +13,7 @@ from .base import ContestBase
 
 class CandidateContest(ContestBase):
     """
-    A subclass of ContestBase for repesenting a contest among candidates.
+    A contest among candidates seeking election to one or more public offices.
     """
     party = models.ForeignKey(
         Organization,
@@ -47,7 +47,7 @@ class CandidateContest(ContestBase):
 @python_2_unicode_compatible
 class CandidateContestPost(models.Model):
     """
-    Link between a CandidateContest and a Post at stake in the contest.
+    A public office (i.e., Post) at stake in a CandidateContest.
     """
     contest = models.ForeignKey(
         CandidateContest,
@@ -72,7 +72,7 @@ class CandidateContestPost(models.Model):
     @property
     def candidacies(self):
         """
-        List of candidacies for the Post in the CandidateContest.
+        List of candidacies for the Post in a CandidateContest.
         """
         return self.contest.candidacies.filter(post=self.post)
 
@@ -87,7 +87,7 @@ class CandidateContestPost(models.Model):
 @python_2_unicode_compatible
 class CandidateContestIdentifier(IdentifierBase):
     """
-    Upstream identifiers of the CandidateContest, if any exist.
+    Upstream identifiers of a CandidateContest.
 
     For example, identfiers assigned by a Secretary of State, county or city
     elections office.
@@ -108,7 +108,7 @@ class CandidateContestIdentifier(IdentifierBase):
 
 class CandidateContestSource(LinkBase):
     """
-    Source used in assembling the CandidateContest.
+    Source used in assembling a CandidateContest.
     """
     contest = models.ForeignKey(
         CandidateContest,

--- a/opencivicdata/elections/models/contests/party.py
+++ b/opencivicdata/elections/models/contests/party.py
@@ -13,7 +13,11 @@ from .base import ContestBase
 
 class PartyContest(ContestBase):
     """
-    Subclass of Contest wherein voters can vote directly for a political party.
+    A contest in which voters can vote directly for a political party.
+
+    In these contests, voters can vote for a party in lieu of/in addition to
+    voting for candidates endorsed by that party (as in the case of party-list
+    proportional representation).
     """
     runoff_for_contest = models.OneToOneField(
         'self',
@@ -29,7 +33,7 @@ class PartyContest(ContestBase):
 @python_2_unicode_compatible
 class PartyContestOption(models.Model):
     """
-    Link between a PartyContest and a Party for which a voter could vote in the election contest.
+    A party (i.e., Organization) voters choose in a PartyContest.
     """
     contest = models.ForeignKey(
         PartyContest,
@@ -60,7 +64,7 @@ class PartyContestOption(models.Model):
 @python_2_unicode_compatible
 class PartyContestIdentifier(IdentifierBase):
     """
-    Upstream identifiers of the PartyMeasureContest, if any exist.
+    Upstream identifiers of a PartyMeasureContest.
 
     For example, identfiers assigned by a Secretary of State, county or city
     elections office.
@@ -82,7 +86,7 @@ class PartyContestIdentifier(IdentifierBase):
 
 class PartyContestSource(LinkBase):
     """
-    Source used in assembling the PartyContest.
+    Source used in assembling a PartyContest.
     """
     contest = models.ForeignKey(
         PartyContest,

--- a/opencivicdata/elections/models/election.py
+++ b/opencivicdata/elections/models/election.py
@@ -64,7 +64,7 @@ class Election(OCDBase):
 @python_2_unicode_compatible
 class ElectionIdentifier(IdentifierBase):
     """
-    Upstream identifiers of the election, if any exist.
+    Upstream identifiers of a Election.
 
     For example, identfiers assigned by a Secretary of State, county or city
     elections office.
@@ -85,7 +85,7 @@ class ElectionIdentifier(IdentifierBase):
 
 class ElectionSource(LinkBase):
     """
-    Source used in assembling the Election.
+    Source used in assembling a Election.
     """
     event = models.ForeignKey(Election, related_name='sources')
 


### PR DESCRIPTION
This pull request adds/edits docstrings on the `core` and `elections` models. I've mostly copied language from the definitions of data types in the relevant OCDEP.

Doesn't require any migrations.

This is an important piece for CCDC because we intend to include these docstrings in our descriptions of the .csv files we publish.

Please let us know if there are any questions/concerns. And many thanks.