### PR TITLE
Fix division unit test

### DIFF
--- a/opencivicdata/tests/test_division.py
+++ b/opencivicdata/tests/test_division.py
@@ -4,7 +4,7 @@ from opencivicdata.divisions import Division
 
 
 def test_get():
-    div = Division.get('ocd-division/country:de/land:bw/wahlkreis:bad_kissingen')
+    div = Division.get('ocd-division/country:de/state:by/cd:248')
     assert div.name == 'Bad Kissingen'
     assert div.name in str(div)
 


### PR DESCRIPTION
Looks like the `test_get` unit test had an obsolete division id. I have replaced it with the current one found [here](https://github.com/opencivicdata/ocd-division-ids/blob/master/identifiers/country-de/wahlkreise.csv).