### PR TITLE
Add became-law action type to pupa

### DIFF
--- a/opencivicdata/common.py
+++ b/opencivicdata/common.py
@@ -133,6 +133,7 @@ BILL_ACTION_CLASSIFICATION_CHOICES = (
     ('executive-signature', 'Signed By Executive'),
     ('executive-veto', 'Veto By Executive'),
     ('executive-veto-line-item', 'Line Item Veto By Executive'),
+    ('became-law', 'Became Law'),
     ('veto-override-passage', 'Veto Override Passage'),
     ('veto-override-failure', 'Veto Override Failure'),
     ('deferral', 'Deferred or Tabled'),


### PR DESCRIPTION
Followup to discussion at https://github.com/openstates/openstates/issues/2027

Many jurisdictions have a way for a way for a bill to become a law without an executive signature, and in some places it's the norm (Kentucky).

This adds a classification that can serve a dual purpose, to flag the actual enactment actions in jurisdictions that provide them, and flag actions where a bill became law without the executive's signature.

Please let me know if this is the wrong spot for this.

@jamesturk @estaub @mileswwatkins 