### PR TITLE
make bulk creation of divisions optional

### DIFF
--- a/opencivicdata/core/management/commands/loaddivisions.py
+++ b/opencivicdata/core/management/commands/loaddivisions.py
@@ -15,7 +15,7 @@ def to_db(fd):
     return Division(id=fd.id, name=fd.name, **args)
 
 
-def load_divisions(country):
+def load_divisions(country, bulk=False):
     existing_divisions = Division.objects.filter(country=country)
 
     country_division = FileDivision.get('ocd-division/country:{}'.format(country))
@@ -30,11 +30,23 @@ def load_divisions(country):
     if set(objects) == set(existing_divisions):
         print('The CSV and the DB contents are exactly the same; no work to be done!')
     else:
-        # delete old ids and add new ones all at once
-        with transaction.atomic():
-            Division.objects.filter(country=country).delete()
-            Division.objects.bulk_create(objects, batch_size=10000)
-        print('{} divisions created'.format(len(objects)))
+        if bulk:
+            # delete old ids and add new ones all at once
+            with transaction.atomic():
+                Division.objects.filter(country=country).delete()
+                Division.objects.bulk_create(objects, batch_size=10000)
+            print('{} divisions created'.format(len(objects)))
+        else:
+            to_create = set(objects) - set(existing_divisions)
+            to_delete = set(existing_divisions) - set(objects)
+            # delete removed ids and add new ones all at once
+            with transaction.atomic():
+                for division in to_delete:
+                    division.delete()
+                for division in to_create:
+                    division.save()
+            print('{} divisions deleted'.format(len(to_delete)))
+            print('{} divisions created'.format(len(to_create)))
 
 
 class Command(BaseCommand):
@@ -42,7 +54,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('countries', nargs='+', type=str)
+        parser.add_argument('--bulk', action='store_true', help='Use bulk_create to add divisions.  *Warning* This deletes any existing divisions')
 
     def handle(self, *args, **options):
         for country in options['countries']:
-            load_divisions(country)
+            load_divisions(country, options['bulk'])


### PR DESCRIPTION
Make bulk delete/create of divisions optional during manage.py
loaddivisions.  That way, if Division is being used as a ForeignKey,
the objects with the ForeignKey won't get deleted(on_delete=CASCADE).