### PR TITLE
add 'judiciary' to ORGANIZATION_CLASSIFICATIONs

### DIFF
--- a/opencivicdata/common.py
+++ b/opencivicdata/common.py
@@ -71,6 +71,7 @@ ORGANIZATION_CLASSIFICATION_CHOICES = (
     ('corporation', 'Corporation'),
     ('agency', 'Agency'),
     ('department', 'Department'),
+    ('judiciary', 'Judiciary'),
 )
 ORGANIZATION_CLASSIFICATIONS = _keys(ORGANIZATION_CLASSIFICATION_CHOICES)
 


### PR DESCRIPTION
I'm modeling some election data from Minnesota where the member of the supreme court are elected. This PR add judiciary as a valid option for organization classification choices.